### PR TITLE
boot.sh only works on Debian-based distros

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-if which apt-get >dev/null; then
-    echo "Make sure you have installed qemu, qemu-user-static, and binfmt-support before using this app.\nPress any key to continue..."
+if ! which apt-get >/dev/null; then
+    echo "Make sure you have installed qemu, qemu-user-static, and binfmt-support before using this app."
+    echo "Press any key to continue..."
     read
 fi
 sudo apt-get install qemu qemu-user-static binfmt-support

--- a/boot.sh
+++ b/boot.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if which apt-get >dev/null; then
+    echo "Make sure you have installed qemu, qemu-user-static, and binfmt-support before using this app.\nPress any key to continue..."
+    read
+fi
 sudo apt-get install qemu qemu-user-static binfmt-support
 if [ ! -d "rpi_image" ]; then
     mkdir rpi_image

--- a/boot.sh
+++ b/boot.sh
@@ -3,8 +3,9 @@ if ! which apt-get >/dev/null; then
     echo "Make sure you have installed qemu, qemu-user-static, and binfmt-support before using this app."
     echo "Press any key to continue..."
     read
+else
+    sudo apt-get install qemu qemu-user-static binfmt-support
 fi
-sudo apt-get install qemu qemu-user-static binfmt-support
 if [ ! -d "rpi_image" ]; then
     mkdir rpi_image
     cd rpi_image


### PR DESCRIPTION
Line two of the file: `sudo apt-get install qemu qemu-user-static binfmt-support`

Requires apt to be installed. This is found on Ubuntu, Linux Mint, and other Debian based distros but many other Linux distros use other package managers (see yum on Fedora, pacman on arch, etc).

This pull request checks if `apt-get` is a valid command before running it, and if it isn't an option it will prompt the user to ensure the packages are installed and skip running the `apt-get` command.